### PR TITLE
Added dataType on ajax call to postURL

### DIFF
--- a/js/infinite-jekyll.js
+++ b/js/infinite-jekyll.js
@@ -1,46 +1,46 @@
 $(function() {
-  
+
   var postURLs,
       isFetchingPosts = false,
       shouldFetchPosts = true,
       postsToLoad = $(".posts").children().length,
       loadNewPostsThreshold = 3000;
-  
+
   // Load the JSON file containing all URLs
   $.getJSON('/all-posts.json', function(data) {
     postURLs = data["posts"];
-    
+
     // If there aren't any more posts available to load than already visible, disable fetching
     if (postURLs.length <= postsToLoad)
       disableFetching();
   });
-	
+
   // If there's no spinner, it's not a page where posts should be fetched
   if ($(".infinite-spinner").length < 1)
     shouldFetchPosts = false;
-	
+
   // Are we close to the end of the page? If we are, load more posts
   $(window).scroll(function(e){
     if (!shouldFetchPosts || isFetchingPosts) return;
-    
+
     var windowHeight = $(window).height(),
         windowScrollPosition = $(window).scrollTop(),
         bottomScrollPosition = windowHeight + windowScrollPosition,
         documentHeight = $(document).height();
-    
+
     // If we've scrolled past the loadNewPostsThreshold, fetch posts
     if ((documentHeight - loadNewPostsThreshold) < bottomScrollPosition) {
       fetchPosts();
     }
   });
-  
+
   // Fetch a chunk of posts
   function fetchPosts() {
     // Exit if postURLs haven't been loaded
     if (!postURLs) return;
-    
+
     isFetchingPosts = true;
-    
+
     // Load as many posts as there were present on the page when it loaded
     // After successfully loading a post, load the next one
     var loadedPosts = 0,
@@ -48,35 +48,39 @@ $(function() {
         callback = function() {
           loadedPosts++;
           var postIndex = postCount + loadedPosts;
-          
+
           if (postIndex > postURLs.length-1) {
             disableFetching();
             return;
           }
-          
+
           if (loadedPosts < postsToLoad) {
             fetchPostWithIndex(postIndex, callback);
           } else {
             isFetchingPosts = false;
           }
         };
-		
+
     fetchPostWithIndex(postCount + loadedPosts, callback);
   }
-	
+
   function fetchPostWithIndex(index, callback) {
     var postURL = postURLs[index];
-		
-    $.get(postURL, function(data) {
-      $(data).find(".post").appendTo(".posts");
-      callback();
+
+    $.ajax({
+      url: postURL,
+      dataType: 'html',
+      success: function(data) {
+        $(data).find(".post").appendTo(".posts");
+        callback();
+      }
     });
   }
-  
+
   function disableFetching() {
     shouldFetchPosts = false;
     isFetchingPosts = false;
     $(".infinite-spinner").fadeOut();
   }
-	
+
 });


### PR DESCRIPTION
It wasn't parsing the html correctly without it, so I changed the `$.get` call to an `$.ajax` with the explicit dataType to `html`. It solved the problem.

I've tested both jQuery 1.10.2 and 1.11.
